### PR TITLE
docs: add Examples/Documentation index

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -1,0 +1,29 @@
+# Documentation Index
+
+- [](&)Documentation/API-Reference.md
+- [](&)Documentation/API.md
+- [](&)Documentation/APIReference.md
+- [](&)Documentation/ArchitectureGuide.md
+- [](&)Documentation/AuthenticationAPI.md
+- [](&)Documentation/AuthenticationGuide.md
+- [](&)Documentation/Best-Practices.md
+- [](&)Documentation/CachingGuide.md
+- [](&)Documentation/ConfigurationAPI.md
+- [](&)Documentation/Getting-Started.md
+- [](&)Documentation/GettingStarted.md
+- [](&)Documentation/GraphQLAPI.md
+- [](&)Documentation/GraphQLGuide.md
+- [](&)Documentation/HTTPClientAPI.md
+- [](&)Documentation/HTTPClientGuide.md
+- [](&)Documentation/Installation.md
+- [](&)Documentation/NetworkingManagerAPI.md
+- [](&)Documentation/PerformanceGuide.md
+- [](&)Documentation/RESTAPIAPI.md
+- [](&)Documentation/RESTAPIGuide.md
+- [](&)Documentation/SecurityAPI.md
+- [](&)Documentation/SecurityGuide.md
+- [](&)Documentation/SyncGuide.md
+- [](&)Documentation/TestingGuide.md
+- [](&)Documentation/Troubleshooting.md
+- [](&)Documentation/WebSocketAPI.md
+- [](&)Documentation/WebSocketGuide.md

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,24 +1,9 @@
-# 💡 Examples
+# Examples Index
 
-Welcome to our comprehensive examples collection! Here you'll find practical implementations and usage patterns for our framework.
-
-## 📱 Available Examples
-
-### Basic Example
-- **File**: `BasicExample.swift`
-- **Description**: Simple implementation showing fundamental usage
-- **Difficulty**: Beginner
-- **Use Case**: Quick prototyping and learning
-
-## 🚀 Getting Started
-
-1. **Choose an example** that matches your skill level
-2. **Copy the code** into your project
-3. **Customize** according to your needs
-4. **Build and run** to see it in action
-
-## 📚 Related Documentation
-
-- [Getting Started](Documentation/GettingStarted.md)
-- [API Reference](Documentation/API.md)
-- [Installation Guide](Documentation/Installation.md)
+- ``Examples/AdvancedCaching/AdvancedCachingExample.swift
+- ``Examples/AdvancedExample.swift
+- ``Examples/BasicExample.swift
+- ``Examples/BasicNetworking/BasicNetworkingExample.swift
+- ``Examples/NetworkAnalytics/NetworkAnalyticsExample.swift
+- ``Examples/RealTimeSync/RealTimeSyncExample.swift
+- ``Examples/RequestInterceptors/RequestInterceptorsExample.swift


### PR DESCRIPTION
Adds repo-specific indices for Examples and Documentation folders. English-only; no placeholders.